### PR TITLE
feat: update believer data retrieval

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "memcached": "^2.2.2",
     "mongoose": "^7.3.1",
     "nodemailer": "^6.9.4",
-    "rate-limit-memcached": "^0.6.0"
+    "rate-limit-memcached": "^0.6.0",
+    "viem": "^1.10.1"
   },
   "lint-staged": {
     "*.js,*.ts,*.cjs,*.mjs": "eslint --fix"

--- a/src/models/ProjectSupporter.ts
+++ b/src/models/ProjectSupporter.ts
@@ -3,8 +3,7 @@ import { Model, ObjectId, Schema, model } from 'mongoose';
 
 export enum ProjectSupporterType {
     Signup,
-    Contribution,
-    Believer
+    Contribution
 }
 
 export interface IProjectSupporter {
@@ -81,30 +80,6 @@ const projectSupporterSchema = new Schema<
             },
             validate: function () {
                 return (this as unknown as IProjectSupporter).type !== 0;
-            }
-        },
-        signatureHash: {
-            type: String,
-            required: function () {
-                return (this as unknown as IProjectSupporter).type === 2;
-            },
-            validate: function () {
-                return (this as unknown as IProjectSupporter).type === 2;
-            }
-        },
-        signedMessage: {
-            type: String,
-            required: function () {
-                return (this as unknown as IProjectSupporter).type === 2;
-            },
-            validate: function () {
-                return (this as unknown as IProjectSupporter).type === 2;
-            }
-        },
-        signingAddress: {
-            type: String,
-            validate: function () {
-                return (this as unknown as IProjectSupporter).type === 2;
             }
         }
     },

--- a/src/paths/projects.ts
+++ b/src/paths/projects.ts
@@ -62,6 +62,11 @@ ProjectsRouter.post(
             });
         }
         (req.body as Record<string, Types.ObjectId>).founder = founder._id;
+        delete (req.body as Record<string, Types.ObjectId>).nftTokenCache;
+        delete (req.body as Record<string, Types.ObjectId>).lastSupporterUpdate;
+        delete (req.body as Record<string, Types.ObjectId>).launched_at;
+        delete (req.body as Record<string, Types.ObjectId>).supporter_count;
+        delete (req.body as Record<string, Types.ObjectId>).vote_count;
         next();
     },
     create(Project, () => true, true),
@@ -123,7 +128,18 @@ ProjectsRouter.patch(
     update(
         Project,
         (req) => req.doc?.founder.toString() === req.user?._id.toString(),
-        { deniedFields: ['status', '__v', 'curation'] }
+        {
+            deniedFields: [
+                'status',
+                '__v',
+                'curation',
+                'nftTokenCache',
+                'lastSupporterUpdate',
+                'launched_at',
+                'supporter_count',
+                'vote_count'
+            ]
+        }
     )
 );
 

--- a/src/paths/projects/supporters.ts
+++ b/src/paths/projects/supporters.ts
@@ -8,6 +8,7 @@ import { json2csv } from 'json-2-csv';
 import contentDisposition from 'content-disposition';
 import rl from '../../ratelimit';
 import Project, { ProjectDocument } from '../../models/Project';
+import { getLogs } from '../../util/alchemy';
 
 const ProjectsSupportersRouter = Router();
 
@@ -31,9 +32,9 @@ ProjectsSupportersRouter.post(
 ProjectsSupportersRouter.get(
     '/believers',
     rl('ProjectSupportersFetch', 30, 15),
-    readMany(ProjectSupporter, () => true, {
-        filter: (req) => ({ project: { $eq: req.doc?._id }, type: 2 })
-    })
+    async (req, res) => {
+        res.json(await getLogs()).end();
+    }
 );
 
 ProjectsSupportersRouter.use(authenticate(true));

--- a/src/util/alchemy.ts
+++ b/src/util/alchemy.ts
@@ -69,3 +69,16 @@ export async function getEditions(): Promise<Edition[]> {
         id: v[4] as string
     }));
 }
+
+export async function getLogs() {
+    const beliefs = await AlchemyAPI.core.getLogs({
+        address: ProjectContractAddress,
+        fromBlock: '0x67e66a1',
+        topics: [
+            '0x7b0cc96a1f808bdffcbf4db4feace8d84ce12e38a462ef7abf3fce622378472c',
+            null,
+            '0x0000000000000000000000000000000000000000000000000000000000000007'
+        ]
+    });
+    return beliefs;
+}

--- a/src/util/alchemy.ts
+++ b/src/util/alchemy.ts
@@ -1,5 +1,7 @@
 import { Alchemy, Network } from 'alchemy-sdk';
 import { ethers } from 'ethers';
+import { createPublicClient, http } from 'viem';
+import { optimism } from 'viem/chains';
 
 // Optional config object, but defaults to the API key 'demo' and Network 'eth-mainnet'.
 const settings = {
@@ -69,15 +71,51 @@ export async function getEditions(): Promise<Edition[]> {
     }));
 }
 
-export async function getLogs() {
-    const beliefs = await AlchemyAPI.core.getLogs({
+const publicClient = createPublicClient({ chain: optimism, transport: http() });
+
+export async function getLogs(editionId: number) {
+    return publicClient.getLogs({
         address: ProjectContractAddress,
-        fromBlock: '0x67e66a1',
-        topics: [
-            '0x7b0cc96a1f808bdffcbf4db4feace8d84ce12e38a462ef7abf3fce622378472c',
-            null,
-            '0x0000000000000000000000000000000000000000000000000000000000000007'
-        ]
+        args: {
+            editionId: BigInt(editionId || 0)
+        },
+        event: {
+            type: 'event',
+            anonymous: false,
+            inputs: [
+                {
+                    name: 'believer',
+                    internalType: 'address',
+                    type: 'address',
+                    indexed: true
+                },
+                {
+                    name: 'editionId',
+                    internalType: 'uint256',
+                    type: 'uint256',
+                    indexed: true
+                },
+                {
+                    name: 'hashOne',
+                    internalType: 'bytes32',
+                    type: 'bytes32',
+                    indexed: false
+                },
+                {
+                    name: 'hashTwo',
+                    internalType: 'bytes32',
+                    type: 'bytes32',
+                    indexed: false
+                },
+                {
+                    name: 'hashThree',
+                    internalType: 'bytes32',
+                    type: 'bytes32',
+                    indexed: false
+                }
+            ],
+            name: 'EditionBelieved'
+        },
+        fromBlock: 108947105n
     });
-    return beliefs;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "es2022",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,6 +12,11 @@
   resolved "https://registry.yarnpkg.com/@adraffy/ens-normalize/-/ens-normalize-1.9.2.tgz#60111a5d9db45b2e5cbb6231b0bb8d97e8659316"
   integrity sha512-0h+FrQDqe2Wn+IIGFkTCd4aAwTJ+7834Ek1COohCyV26AXhwQ7WQaz+4F/nLOeVl/3BtWHOHLPsq46V8YB46Eg==
 
+"@adraffy/ens-normalize@1.9.4":
+  version "1.9.4"
+  resolved "https://registry.yarnpkg.com/@adraffy/ens-normalize/-/ens-normalize-1.9.4.tgz#aae21cb858bbb0411949d5b7b3051f4209043f62"
+  integrity sha512-UK0bHA7hh9cR39V+4gl2/NnBBjoXIxkuWAPCaY4X7fbH4L/azIi7ilWOCjMUYfpJgraLUAqkRi2BqrjME8Rynw==
+
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
@@ -418,10 +423,22 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@noble/curves@1.2.0", "@noble/curves@~1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.2.0.tgz#92d7e12e4e49b23105a2555c6984d41733d65c35"
+  integrity sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==
+  dependencies:
+    "@noble/hashes" "1.3.2"
+
 "@noble/hashes@1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.1.2.tgz#e9e035b9b166ca0af657a7848eb2718f0f22f183"
   integrity sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==
+
+"@noble/hashes@1.3.2", "@noble/hashes@~1.3.0", "@noble/hashes@~1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.2.tgz#6f26dbc8fbc7205873ce3cee2f690eba0d421b39"
+  integrity sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==
 
 "@noble/secp256k1@1.7.1":
   version "1.7.1"
@@ -448,6 +465,28 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
+
+"@scure/base@~1.1.0", "@scure/base@~1.1.2":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.3.tgz#8584115565228290a6c6c4961973e0903bb3df2f"
+  integrity sha512-/+SgoRjLq7Xlf0CWuLHq2LUZeL/w65kfzAPG5NH9pcmBhs+nunQTn4gvdwgMTIXnt9b2C/1SeL2XiysZEyIC9Q==
+
+"@scure/bip32@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@scure/bip32/-/bip32-1.3.2.tgz#90e78c027d5e30f0b22c1f8d50ff12f3fb7559f8"
+  integrity sha512-N1ZhksgwD3OBlwTv3R6KFEcPojl/W4ElJOeCZdi+vuI5QmTFwLq3OFf2zd2ROpKvxFdgZ6hUpb0dx9bVNEwYCA==
+  dependencies:
+    "@noble/curves" "~1.2.0"
+    "@noble/hashes" "~1.3.2"
+    "@scure/base" "~1.1.2"
+
+"@scure/bip39@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@scure/bip39/-/bip39-1.2.1.tgz#5cee8978656b272a917b7871c981e0541ad6ac2a"
+  integrity sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg==
+  dependencies:
+    "@noble/hashes" "~1.3.0"
+    "@scure/base" "~1.1.0"
 
 "@tsconfig/node10@^1.0.7":
   version "1.0.9"
@@ -638,6 +677,13 @@
     "@types/node" "*"
     "@types/webidl-conversions" "*"
 
+"@types/ws@^8.5.5":
+  version "8.5.5"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.5.tgz#af587964aa06682702ee6dcbc7be41a80e4b28eb"
+  integrity sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==
+  dependencies:
+    "@types/node" "*"
+
 "@typescript-eslint/eslint-plugin@^5.60.1":
   version "5.62.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz#aeef0328d172b9e37d9bab6dbc13b87ed88977db"
@@ -721,6 +767,11 @@
   dependencies:
     "@typescript-eslint/types" "5.62.0"
     eslint-visitor-keys "^3.3.0"
+
+abitype@0.9.8:
+  version "0.9.8"
+  resolved "https://registry.yarnpkg.com/abitype/-/abitype-0.9.8.tgz#1f120b6b717459deafd213dfbf3a3dd1bf10ae8c"
+  integrity sha512-puLifILdm+8sjyss4S+fsUN09obiT1g2YW6CtcQF+QDzxR0euzgEB29MZujC6zMk2a6SVmtttq1fc6+YFA7WYQ==
 
 accepts@~1.3.8:
   version "1.3.8"
@@ -1813,6 +1864,11 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
+isomorphic-ws@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz#e5529148912ecb9b451b46ed44d53dae1ce04bbf"
+  integrity sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==
+
 jackpot@>=0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/jackpot/-/jackpot-0.0.6.tgz#3cff064285cbf66f4eab2593c90bce816a821849"
@@ -2713,6 +2769,21 @@ vary@^1, vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
 
+viem@^1.10.1:
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/viem/-/viem-1.10.1.tgz#b91a2e5e583e94d61c210391322de01692f19a07"
+  integrity sha512-rN2GhbEElz47z0aOXly4A+XLGNNQJkCUR03pL9EoRVbMpAPf7mK3Pk0m7crRvBesb0xiS8rgIg0Ip50fq9vWIw==
+  dependencies:
+    "@adraffy/ens-normalize" "1.9.4"
+    "@noble/curves" "1.2.0"
+    "@noble/hashes" "1.3.2"
+    "@scure/bip32" "1.3.2"
+    "@scure/bip39" "1.2.1"
+    "@types/ws" "^8.5.5"
+    abitype "0.9.8"
+    isomorphic-ws "5.0.0"
+    ws "8.13.0"
+
 webidl-conversions@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
@@ -2763,6 +2834,11 @@ ws@7.4.6:
   version "7.4.6"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
   integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
+
+ws@8.13.0:
+  version "8.13.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.13.0.tgz#9a9fb92f93cf41512a0735c8f4dd09b8a1211cd0"
+  integrity sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==
 
 ws@8.5.0:
   version "8.5.0"


### PR DESCRIPTION
As we are moving the signature data on-chain, the "believer" data is stored in Events, which can be retrieved with alchemy's getLog method.

The issue is that the event looks something like this, where editionId refers to the index of the edition on chain. This means that we should call `contract.getEditions()` to derive the database project id => on chain project id again.

```
{
  type: 'event',
  anonymous: false,
  inputs: [
    {
      name: 'believer',
      internalType: 'address',
      type: 'address',
      indexed: true,
    },
    {
      name: 'editionId',
      internalType: 'uint256',
      type: 'uint256',
      indexed: true,
    },
    {
      name: 'hashOne',
      internalType: 'bytes32',
      type: 'bytes32',
      indexed: false,
    },
    {
      name: 'hashTwo',
      internalType: 'bytes32',
      type: 'bytes32',
      indexed: false,
    },
    {
      name: 'hashThree',
      internalType: 'bytes32',
      type: 'bytes32',
      indexed: false,
    },
  ],
  name: 'EditionBelieved',
}
```

I have added a util function in `alchemy.ts` file to retrieve said logs. Which we can then filter the return value for the specific project.

Here `believer` is the address of the user who clicked "believe". 